### PR TITLE
Optimizing Workout Details page layout

### DIFF
--- a/qml/pages/DetailedViewPage.qml
+++ b/qml/pages/DetailedViewPage.qml
@@ -214,15 +214,7 @@ Page
                         iPausePositionsIndex++;
                 }
             }
-
-            if (trackLoader.pausePositionsCount() === 0)
-                pauseData.text = "-" ;
-            else
-                pauseData.text = trackLoader.pausePositionsCount().toString() + "/" + trackLoader.pauseDurationStr;
-
             console.log("onTrackChanged: " + JSTools.arrayDataPoints.length.toString());
-
-
         }
         onLoadedChanged:
         {
@@ -375,6 +367,7 @@ Page
 
         Column
         {
+            id: details_column
             width: parent.width
             PageHeader
             {
@@ -407,13 +400,15 @@ Page
                     color: Theme.secondaryColor
                     font.pixelSize: Theme.fontSizeSmall
                     text: qsTr("Description:")
+                    visible: trackLoader.description !== ""
                 }
                 Label
                 {
                     id: descriptionData
                     width: parent.width - descriptionLabel.width - 2*Theme.paddingLarge
-                    text: trackLoader.description==="" ? "-" : trackLoader.description
+                    text: trackLoader.description
                     wrapMode: Text.WordWrap
+                    visible: trackLoader.description !== ""
                 }
                 Label
                 {
@@ -505,12 +500,14 @@ Page
                     color: Theme.secondaryColor
                     font.pixelSize: Theme.fontSizeSmall
                     text: qsTr("Heart rate min/max/⌀:")
+                    visible:  trackLoader.hasHeartRateData()
                 }
                 Label
                 {
                     id: heartRateData
                     width: descriptionData.width
-                    text: (trackLoader.heartRateMin === 9999999 && trackLoader.heartRateMax === 0) ? "-" : trackLoader.heartRateMin + "/" + trackLoader.heartRateMax + "/" + trackLoader.heartRate.toFixed(1) + " bpm"
+                    text: trackLoader.hasHeartRateData() ? "-" : trackLoader.heartRateMin + "/" + trackLoader.heartRateMax + "/" + trackLoader.heartRate.toFixed(1) + " bpm"
+                    visible:  trackLoader.hasHeartRateData()
                 }
                 Label
                 {
@@ -522,11 +519,14 @@ Page
                     color: Theme.secondaryColor
                     font.pixelSize: Theme.fontSizeSmall
                     text: qsTr("Pause number/duration:")
+                    visible: (trackLoader.pausePositionsCount() > 0)
                 }
                 Label
                 {
                     id: pauseData
                     width: descriptionData.width
+                    text: trackLoader.pauseNumbersString()
+                    visible: (trackLoader.pausePositionsCount() > 0)
                 }
                 Label
                 {
@@ -555,7 +555,7 @@ Page
         id: map
 
         width: parent.width
-        height: bMapMaximized ? detailPage.height : detailPage.height / 3
+        height: bMapMaximized ? detailPage.height : detailPage.height - details_column.height - Theme.paddingMedium
         anchors.bottom: parent.bottom
 
         center: QtPositioning.coordinate(51.9854, 9.2743)

--- a/src/trackloader.cpp
+++ b/src/trackloader.cpp
@@ -39,8 +39,8 @@ TrackLoader::TrackLoader(QObject *parent) :
     m_distance = 0;
     m_heartRate = 0;
     m_heartRatePoints = 0;
-    m_heartRateMin = 9999999;
-    m_heartRateMax = 0;
+    m_heartRateMin = HEARTRATE_MIN_INIT;
+    m_heartRateMax = HEARTRATE_MAX_INIT;
     m_sTkey = "";
     m_elevationUp = 0;
     m_elevationDown = 0;
@@ -158,6 +158,18 @@ void TrackLoader::vWriteFile(QString sFilename)
         return;
     }
     fOut.close();
+}
+
+bool TrackLoader::hasHeartRateData() const
+{
+    return !(m_heartRateMin == HEARTRATE_MIN_INIT && m_heartRateMax == HEARTRATE_MAX_INIT);
+}
+
+QString TrackLoader::pauseNumbersString() const
+{
+    if (m_pause_positions.count() == 0)
+        return QStringLiteral("-");
+    return QString("%1/%2").arg(m_pause_positions.count()).arg(m_pause_duration);
 }
 
 void TrackLoader::load()

--- a/src/trackloader.h
+++ b/src/trackloader.h
@@ -23,6 +23,9 @@
 #include <QGeoCoordinate>
 #include <QXmlStreamReader>
 
+#define HEARTRATE_MIN_INIT 9999999
+#define HEARTRATE_MAX_INIT 0
+
 class TrackLoader : public QObject
 {
     Q_OBJECT
@@ -110,6 +113,10 @@ public:
     Q_INVOKABLE void vReadFile(QString sFilename);
     Q_INVOKABLE void vSetNewProperties(QString sOldName, QString sOldDesc, QString sOldWorkout, QString sName, QString sDesc, QString sWorkout);
     Q_INVOKABLE void vWriteFile(QString sFilename);
+
+    Q_INVOKABLE bool hasHeartRateData() const;
+
+    Q_INVOKABLE QString pauseNumbersString() const;
 
 signals:
     void filenameChanged();


### PR DESCRIPTION
I think it is unnecessary to display fields which does not acceptable/blank in the details view.
This patch hide the following information from the details screen if not acceptable/present to make more room for the map:
- Heartrate
- Description
- Number of pauses

I have modified the map sizing to occupy as much area as is possible (including padding of course):
![kepernyomentes_20180607_001](https://user-images.githubusercontent.com/1609182/41067421-d31aa600-69e5-11e8-9b9c-e9a0ad82b355.png)

I think in the future it would be great to add (flickable) charts/graphs to the place where now the map is so making more room there is a good starting point. 

I would also recommend to hide the pace values if the workout type is a bike workout. But that is only my 50 cents I would like to hear others opinion about it.