### PR TITLE
Hide filter when all workouts have the same type

### DIFF
--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -468,14 +468,13 @@ Page
             {
                 id: itmMainHeaderArea
                 width: parent.width
-                height: (mainPage.height - pageHeader.height) / 3.9
-
+                height: ((mainPage.height - pageHeader.height) / (filterItem.visible ? 3.9 : 5.85))
                 Item
                 {                    
+                    id: filterItem
                     width: parent.width
-                    height: parent.height / 3.2
-                    visible: !bLoadingFiles
-
+                    height: visible ? parent.height / 3.2 : 0
+                    visible: !bLoadingFiles && !id_HistoryModel.allWorkoutTypeIdentical
                     Row
 				    {
 				        width: parent.width
@@ -522,7 +521,7 @@ Page
                     anchors.leftMargin: Theme.paddingLarge
                     anchors.bottom: parent.bottom
                     width: parent.width - Theme.paddingLarge
-                    height: (parent.height / 3) * 2
+                    height: filterItem.visible ? (parent.height / 3) * 2 : parent.height
                     visible: !bLoadingFiles                    
 
                     Item

--- a/src/historymodel.h
+++ b/src/historymodel.h
@@ -60,6 +60,7 @@ public:
     ~HistoryModel();
 
 	Q_PROPERTY(bool gpxFilesChanged READ gpxFilesChanged WRITE setGpxFilesChanged)
+    Q_PROPERTY(bool allWorkoutTypeIdentical READ allWorkoutTypeIdentical NOTIFY sigAllWorkoutTypeIdenticalChanged)
 
     QHash<int, QByteArray> roleNames() const;
     int rowCount(const QModelIndex&) const;
@@ -83,11 +84,14 @@ public:
     Q_INVOKABLE qreal distanceAt(int index);
     Q_INVOKABLE QDateTime dateAt(int index);
 
+    Q_INVOKABLE bool allWorkoutTypeIdentical() const;
+
 
 signals:
     void sigLoadingFinished();
     void sigLoadingError();
     void sigAmountGPXFiles(int iAmountGPXFiles);
+    void sigAllWorkoutTypeIdenticalChanged();
 
 public slots:
     void newTrackData(int num);
@@ -103,7 +107,9 @@ private:
     int iWorkoutDuration;	
     qreal rWorkoutDistance;
 	bool bGPXFilesChanged;
+    bool bAllWorkoutSameType = true;
     static bool bCompareDates(const TrackItem &ti1, const TrackItem &ti2);    
+    void updateAllWorkoutTypeIdentical();
 };
 
 #endif // HISTORYMODEL_H


### PR DESCRIPTION
Hi Jens,

I use the Laufhelden for roadbiking only, so all of my workouts have the same type.
I think it would be useful to hide the filter in this case to gain more space:
![kepernyomentes_20181107_001](https://user-images.githubusercontent.com/1609182/48154333-a38c0800-e2c8-11e8-894f-f3035b903d03.png)

When having mixed workout types the filter is visible as before:
![kepernyomentes_20181107_002](https://user-images.githubusercontent.com/1609182/48154346-ae469d00-e2c8-11e8-9251-74d653c40160.png)
