### PR TITLE
Uniformize the duration display further

### DIFF
--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -49,20 +49,16 @@ Page
         id: trackLoader
     }
 
+    TimeFormatter
+    {
+        id: timeFormatter
+    }
+
     function fncSetWorkoutFilter()
     {
         sWorkoutDistance = (settings.measureSystem === 0) ? (SharedResources.arrayLookupWorkoutFilterMainPageTableByName[settings.workoutTypeMainPage].iDistance/1000).toFixed(2) + qsTr("km") : JSTools.fncConvertDistanceToImperial(SharedResources.arrayLookupWorkoutTableByName[settings.workoutTypeMainPage].iDistance/1000).toFixed(2) + qsTr("mi");
 
-        var iDuration = SharedResources.arrayLookupWorkoutFilterMainPageTableByName[settings.workoutTypeMainPage].iDuration;
-        iDuration = Math.floor(iDuration);
-        var hours = iDuration / (60*60);
-        hours = Math.floor(hours);
-        var minutes = (iDuration - hours*60*60) / 60;
-        minutes = Math.floor(minutes);
-        var seconds = iDuration - hours*60*60 - minutes*60;
-        seconds = Math.floor(seconds);
-
-        sWorkoutDuration = (JSTools.fncPadZeros(hours, 2)).toString() + "h " + (JSTools.fncPadZeros(minutes, 2)).toString() + "m " + (JSTools.fncPadZeros(seconds, 2)).toString() + "s";
+        sWorkoutDuration = timeFormatter.formatHMS_fromSeconds(SharedResources.arrayLookupWorkoutFilterMainPageTableByName[settings.workoutTypeMainPage].iDuration);
 
         sWorkoutCount = (SharedResources.arrayLookupWorkoutFilterMainPageTableByName[settings.workoutTypeMainPage].iWorkouts).toString();
 

--- a/src/harbour-laufhelden.cpp
+++ b/src/harbour-laufhelden.cpp
@@ -34,6 +34,7 @@
 #include "light.h"
 #include "pebblemanagercomm.h"
 #include "pebblewatchcomm.h"
+#include "timeformatter.h"
 #include "o2/src/o2.h"
 
 QByteArray encryptDecrypt(QByteArray toEncrypt) {
@@ -63,6 +64,7 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<LogWriter,1>("harbour.laufhelden", 1, 0, "LogWriter");
     qmlRegisterType<PlotWidget,1>("harbour.laufhelden", 1, 0, "PlotWidget");
     qmlRegisterType<Light,1>("harbour.laufhelden", 1, 0, "Light");
+    qmlRegisterType<TimeFormatter,1>("harbour.laufhelden", 1, 0, "TimeFormatter");
     qmlRegisterType<PebbleManagerComm,1>("harbour.laufhelden", 1, 0, "PebbleManagerComm");
     qmlRegisterType<PebbleWatchComm,1>("harbour.laufhelden", 1, 0, "PebbleWatchComm");
     qmlRegisterType<O2>("com.pipacs.o2", 1, 0, "O2");

--- a/src/timeformatter.cpp
+++ b/src/timeformatter.cpp
@@ -1,5 +1,6 @@
 #include "timeformatter.h"
 #include <QObject>
+#include <qmath.h>
 
 /**
  * @brief TimeFormatter::formatHMS
@@ -12,7 +13,18 @@
  * @param seconds
  * @return
  */
-QString TimeFormatter::formatHMS(uint hours, uint minutes, uint seconds)
+QString TimeFormatter::formatHMS_fromSeconds(const uint durationInSec)
+{
+    uint hours = durationInSec / (60*60);
+    hours = qFloor(hours);
+    uint minutes = (durationInSec - hours*60*60) / 60;
+    minutes = qFloor(minutes);
+    uint seconds = durationInSec - hours*60*60 - minutes*60;
+    seconds = qFloor(seconds);
+    return formatHMS(hours, minutes, seconds);
+}
+
+QString TimeFormatter::formatHMS(const uint hours, const uint minutes, const uint seconds)
 {
     if(hours == 0)
     {

--- a/src/timeformatter.h
+++ b/src/timeformatter.h
@@ -1,12 +1,15 @@
 #ifndef TIMEFORMATTER_H
 #define TIMEFORMATTER_H
 
+#include <QObject>
 #include <QString>
 
-class TimeFormatter
+class TimeFormatter : public QObject
 {
+    Q_OBJECT
 public:
-    static QString formatHMS(uint hours, uint minutes, uint seconds);
+    Q_INVOKABLE static QString formatHMS_fromSeconds(const uint seconds);
+    Q_INVOKABLE static QString formatHMS(const uint hours, const uint minutes, const uint seconds);
 };
 
 #endif // TIMEFORMATTER_H


### PR DESCRIPTION
This PR continues the work started in the #88:
On the main screen the filtered duration had a 0 prefix before the hours:
![kep](https://user-images.githubusercontent.com/1609182/48158215-3e3d1480-e2d2-11e8-9447-72be3c78e04d.png)

And the h,m,s strings were not translatable. Now this duration is displayed through the TimeFormatter class, so it should look like the same way as the rest of the durations in the app. 