### PR TITLE
Removed duplicate inclusion of serviceinfo.h

### DIFF
--- a/harbour-laufhelden.pro
+++ b/harbour-laufhelden.pro
@@ -75,7 +75,6 @@ HEADERS += \
     src/timeformatter.h \
     src/device.h \
     src/deviceinfo.h \
-    src/serviceinfo.h \
     src/serviceinfo.h
 
 DISTFILES += \


### PR DESCRIPTION
Because it caused warnings when qmake ran.