### PR TITLE
reset workgout aggregation on reloading

### DIFF
--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -323,6 +323,13 @@ Page
 
             filterProxyModel.sourceModel = id_HistoryModel;
 
+            // reset distance and duration in arrayLookupWorkoutFilterMainPageTableByName
+            for (var type in SharedResources.arrayLookupWorkoutFilterMainPageTableByName){
+                SharedResources.arrayLookupWorkoutFilterMainPageTableByName[type].iDistance = 0;
+                SharedResources.arrayLookupWorkoutFilterMainPageTableByName[type].iDuration = 0;
+            }
+
+
             var sWorkoutCurrent, fDistanceCurrent, iDurationCurrent
             //Go through all workouts
             for (var i = 0; i < id_HistoryModel.rowCount(); i++)


### PR DESCRIPTION
when some workout is modified, aggregation used on main page is not reset and distance/time is incorrect then... This patch fix it.
 
![screenshot_20181230_001](https://user-images.githubusercontent.com/309458/50550653-bab9f700-0c74-11e9-925f-c80250a5d99a.png)
