### PR TITLE
Update pace string formatting

### DIFF
--- a/src/trackloader.cpp
+++ b/src/trackloader.cpp
@@ -1010,49 +1010,50 @@ QDateTime TrackLoader::timeAt(int index)
 {
     return m_points.at(index).time;
 }
+
 qint64 TrackLoader::unixTimeAt(int index)
 {
     return m_points.at(index).time.toMSecsSinceEpoch() / 1000;
 }
+
 qreal TrackLoader::durationAt(int index)
 {
     return m_points.at(index).duration;
 }
+
 qreal TrackLoader::distanceAt(int index)
 {
     return m_points.at(index).distance;
 }
+
 qreal TrackLoader::speedAt(int index)
 {
     return m_points.at(index).speed;
 }
+
 qreal TrackLoader::paceAt(int index)
 {
     return m_points.at(index).pace;
 }
+
 QString TrackLoader::paceStrAt(int index)
 {
-    QString strPace = "";
-
-    qreal rMinutes = qFloor(m_points.at(index).pace);
-    qreal rSeconds = qCeil((m_points.at(index).pace * 60) - (rMinutes * 60));
-
-    strPace = QString::number(rMinutes) + ":" + QString::number(rSeconds);
-
-    return strPace;
+    return paceToStr(m_points.at(index).pace);
 }
+
 QString TrackLoader::paceImperialStrAt(int index)
 {
-    qreal m_pace_imperial = m_points.at(index).pace * 1.609344;
+    return paceToStr(m_points.at(index).pace * 1.609344);
+}
 
-    QString strPace = "";
+QString TrackLoader::paceToStr(qreal pace)
+{
+    int minutes = qFloor(pace);
+    int seconds = qCeil((pace * 60) - (minutes * 60));
 
-    qreal rMinutes = qFloor(m_pace_imperial);
-    qreal rSeconds = qCeil((m_pace_imperial * 60) - (rMinutes * 60));
-
-    strPace = QString::number(rMinutes) + ":" + QString::number(rSeconds);
-
-    return strPace;
+    return QString("%1:%2")
+            .arg(minutes)
+            .arg(seconds, 2, 10, QLatin1Char('0'));
 }
 
 int TrackLoader::fitZoomLevel(int width, int height) {

--- a/src/trackloader.h
+++ b/src/trackloader.h
@@ -149,6 +149,7 @@ public slots:
 
 private:
     void load();
+    QString paceToStr(qreal pace);
 
     QList<TrackPoint> m_points;
     QList<int> m_pause_positions;


### PR DESCRIPTION
Hi,

actually pace is displayed as min:s (e.g: 4:36, 2:3).
In case of seconds value under 10, pace rendering doesn't display leading zero.
I have update and refactored paceStrAt functions to display this zero.