### PR TITLE
Padding fixes

### DIFF
--- a/qml/components/InfoItem.qml
+++ b/qml/components/InfoItem.qml
@@ -4,6 +4,7 @@ import Sailfish.Silica 1.0
 Item {
     property alias label: label.text
     property alias value: value.text
+    property alias leftPadding: label.leftPadding
     anchors.left: parent.left
     anchors.right: parent.right
     height: value.height
@@ -11,6 +12,7 @@ Item {
         id: label
         color: Theme.secondaryColor
         text: "Label"
+        rightPadding: Theme.paddingSmall
     }
     Label {
         id: value

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -142,6 +142,7 @@ Page
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.secondaryColor
                 text: "niemisenjussi, piggz, atlochowski, eson57, martonmiklos, d9h20f, carmenfdezb, dikonov, thmichel, trouyer, ncartron"
+                leftPadding: Theme.paddingMedium
             }            
             Item
             {

--- a/qml/pages/DetailedViewPage.qml
+++ b/qml/pages/DetailedViewPage.qml
@@ -361,39 +361,46 @@ Page
             {
                 label: qsTr("Starting time:")
                 value: trackLoader.timeStr
+                leftPadding: Theme.paddingMedium
             }
             InfoItem
             {
                 label: qsTr("Duration:")
                 value: trackLoader.durationStr
+                leftPadding: Theme.paddingMedium
             }
             InfoItem
             {
                 label: qsTr("Distance:")
                 value: (settings.measureSystem === 0) ? ((trackLoader.distance/1000).toFixed(2) + " km") : (JSTools.fncConvertDistanceToImperial(trackLoader.distance/1000).toFixed(2) + " mi")
+                leftPadding: Theme.paddingMedium
             }
             InfoItem
             {
                 label: qsTr("Speed max/⌀:")
                 value: (settings.measureSystem === 0) ? (trackLoader.maxSpeed*3.6).toFixed(1) + "/" + (trackLoader.speed*3.6).toFixed(1) + " km/h" : (JSTools.fncConvertSpeedToImperial(trackLoader.maxSpeed*3.6)).toFixed(1) + "/" + (JSTools.fncConvertSpeedToImperial(trackLoader.speed*3.6)).toFixed(1) + " mi/h"
+                leftPadding: Theme.paddingMedium
             }
             InfoItem
             {
                 visible: bPaceRelevantForWorkoutType
                 label: qsTr("Pace ⌀:")
                 value: (settings.measureSystem === 0) ? trackLoader.paceStr + " min/km" : trackLoader.paceImperialStr + " min/mi"
+                leftPadding: Theme.paddingMedium
             }
             InfoItem
             {
                 visible: bHeartrateSupported
                 label: qsTr("Heart rate min/max/⌀:")
                 value: trackLoader.heartRateMin + "/" + trackLoader.heartRateMax + "/" + trackLoader.heartRate.toFixed(1) + " bpm"
+                leftPadding: Theme.paddingMedium
             }
             InfoItem
             {
                 visible: (iPausePositionsCount > 0)
                 label: qsTr("Pause number/duration:")
                 value: trackLoader.pauseDurationStr
+                leftPadding: Theme.paddingMedium
             }
         }
     }

--- a/qml/pages/DiagramViewPage.qml
+++ b/qml/pages/DiagramViewPage.qml
@@ -309,21 +309,21 @@ Page
             anchors.left: parent.left
             anchors.top: parent.top
             anchors.topMargin: Theme.paddingMedium
-            anchors.leftMargin: Theme.paddingSmall
+            anchors.leftMargin: Theme.paddingMedium
 
             InfoItem
             {
-                label: qsTr("Time: ")
+                label: qsTr("Time:")
                 value: sCurrentTime
             }
             InfoItem
             {
-                label: qsTr("Duration: ")
+                label: qsTr("Duration:")
                 value: sCurrentDuration
             }
             InfoItem
             {
-                label: qsTr("Elevation: ")
+                label: qsTr("Elevation:")
                 value: sCurrentElevation
             }
         }
@@ -338,18 +338,18 @@ Page
 
             InfoItem
             {
-                label: qsTr("Pace: ")
+                label: qsTr("Pace:")
                 value: sCurrentPace
             }
             InfoItem
             {
-                label: qsTr("Speed: ")
+                label: qsTr("Speed:")
                 value: sCurrentSpeed
             }
             InfoItem
             {
                 visible: bHeartrateSupported
-                label: qsTr("Heartrate: ")
+                label: qsTr("Heartrate:")
                 value: sCurrentHeartrate
             }
         }

--- a/qml/pages/MapViewPage.qml
+++ b/qml/pages/MapViewPage.qml
@@ -476,21 +476,21 @@ Page
             anchors.top: parent.top
 
             anchors.topMargin: Theme.paddingMedium
-            anchors.leftMargin: Theme.paddingSmall
+            anchors.leftMargin: Theme.paddingMedium
 
             InfoItem
             {
-                label: qsTr("Time: ")
+                label: qsTr("Time:")
                 value: sCurrentTime
             }
             InfoItem
             {
-                label: qsTr("Duration: ")
+                label: qsTr("Duration:")
                 value: sCurrentDuration
             }
             InfoItem
             {
-                label: qsTr("Elevation: ")
+                label: qsTr("Elevation:")
                 value: sCurrentElevation
             }
         }
@@ -504,18 +504,18 @@ Page
             anchors.topMargin: Theme.paddingMedium
             InfoItem
             {
-                label: qsTr("Pace: ")
+                label: qsTr("Pace:")
                 value: sCurrentPace
             }
             InfoItem
             {
-                label: qsTr("Speed: ")
+                label: qsTr("Speed:")
                 value: sCurrentSpeed
             }
             InfoItem
             {
                 visible: bHeartrateSupported
-                label: qsTr("Heartrate: ")
+                label: qsTr("Heartrate:")
                 value: sCurrentHeartrate
             }
         }

--- a/translations/harbour-laufhelden-de.ts
+++ b/translations/harbour-laufhelden-de.ts
@@ -251,28 +251,28 @@
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Zeit: </translation>
+        <source>Time:</source>
+        <translation>Zeit:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Dauer: </translation>
+        <source>Duration:</source>
+        <translation>Dauer:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Höhe: </translation>
+        <source>Elevation:</source>
+        <translation>Höhe:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Tempo: </translation>
+        <source>Pace:</source>
+        <translation>Tempo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Geschwindigkeit: </translation>
+        <source>Speed:</source>
+        <translation>Geschwindigkeit:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Herzfreuenz: </translation>
+        <source>Heartrate:</source>
+        <translation>Herzfreuenz:</translation>
     </message>
     <message>
         <source>km</source>
@@ -513,28 +513,28 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
-        <translation>Zeit: </translation>
+        <source>Time:</source>
+        <translation>Zeit:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Dauer: </translation>
+        <source>Duration:</source>
+        <translation>Dauer:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Höhe: </translation>
+        <source>Elevation:</source>
+        <translation>Höhe:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Tempo: </translation>
+        <source>Pace:</source>
+        <translation>Tempo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Geschwindigkeit: </translation>
+        <source>Speed:</source>
+        <translation>Geschwindigkeit:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Herzfrequenz: </translation>
+        <source>Heartrate:</source>
+        <translation>Herzfrequenz:</translation>
     </message>
     <message>
         <source>km</source>

--- a/translations/harbour-laufhelden-es.ts
+++ b/translations/harbour-laufhelden-es.ts
@@ -251,28 +251,28 @@
         <translation>Velocidad</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Hora: </translation>
+        <source>Time:</source>
+        <translation>Hora:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Duración: </translation>
+        <source>Duration:</source>
+        <translation>Duración:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Altitud: </translation>
+        <source>Elevation:</source>
+        <translation>Altitud:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Ritmo: </translation>
+        <source>Pace:</source>
+        <translation>Ritmo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Velocidad: </translation>
+        <source>Speed:</source>
+        <translation>Velocidad:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Frec. card: </translation>
+        <source>Heartrate:</source>
+        <translation>Frec. card:</translation>
     </message>
     <message>
         <source>km</source>
@@ -513,28 +513,28 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
-        <translation>Hora: </translation>
+        <source>Time:</source>
+        <translation>Hora:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Duración: </translation>
+        <source>Duration:</source>
+        <translation>Duración:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Altitud: </translation>
+        <source>Elevation:</source>
+        <translation>Altitud:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Ritmo: </translation>
+        <source>Pace:</source>
+        <translation>Ritmo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Velocidad: </translation>
+        <source>Speed:</source>
+        <translation>Velocidad:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Frec. card.: </translation>
+        <source>Heartrate:</source>
+        <translation>Frec. card.:</translation>
     </message>
     <message>
         <source>km</source>

--- a/translations/harbour-laufhelden-fi_FI.ts
+++ b/translations/harbour-laufhelden-fi_FI.ts
@@ -251,27 +251,27 @@
         <translation type="unfinished">Nopeus</translation>
     </message>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -513,27 +513,27 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/harbour-laufhelden-fr.ts
+++ b/translations/harbour-laufhelden-fr.ts
@@ -251,28 +251,28 @@
         <translation>Vitesse</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Heure: </translation>
+        <source>Time:</source>
+        <translation>Heure:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Durée: </translation>
+        <source>Duration:</source>
+        <translation>Durée:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Altitude: </translation>
+        <source>Elevation:</source>
+        <translation>Altitude:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Cadence: </translation>
+        <source>Pace:</source>
+        <translation>Cadence:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Vitesse: </translation>
+        <source>Speed:</source>
+        <translation>Vitesse:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Fréq. cardiaque: </translation>
+        <source>Heartrate:</source>
+        <translation>Fréq. cardiaque:</translation>
     </message>
     <message>
         <source>km</source>
@@ -513,28 +513,28 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
-        <translation>Heure: </translation>
+        <source>Time:</source>
+        <translation>Heure:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Durée: </translation>
+        <source>Duration:</source>
+        <translation>Durée:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Altitude: </translation>
+        <source>Elevation:</source>
+        <translation>Altitude:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Cadence: </translation>
+        <source>Pace:</source>
+        <translation>Cadence:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Vitesse: </translation>
+        <source>Speed:</source>
+        <translation>Vitesse:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Fréq. cardiaque: </translation>
+        <source>Heartrate:</source>
+        <translation>Fréq. cardiaque:</translation>
     </message>
     <message>
         <source>km</source>

--- a/translations/harbour-laufhelden-hu.ts
+++ b/translations/harbour-laufhelden-hu.ts
@@ -263,28 +263,28 @@
         <translation>Magasság</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Időpont: </translation>
+        <source>Time:</source>
+        <translation>Időpont:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Eltelt idő: </translation>
+        <source>Duration:</source>
+        <translation>Eltelt idő:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Magasság: </translation>
+        <source>Elevation:</source>
+        <translation>Magasság:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Lépés: </translation>
+        <source>Pace:</source>
+        <translation>Lépés:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Sebesség: </translation>
+        <source>Speed:</source>
+        <translation>Sebesség:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Pulzus: </translation>
+        <source>Heartrate:</source>
+        <translation>Pulzus:</translation>
     </message>
 </context>
 <context>
@@ -525,28 +525,28 @@
         <translation>Térkép</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Időpont: </translation>
+        <source>Time:</source>
+        <translation>Időpont:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Eltelt idő: </translation>
+        <source>Duration:</source>
+        <translation>Eltelt idő:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Magasság: </translation>
+        <source>Elevation:</source>
+        <translation>Magasság:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Lépés: </translation>
+        <source>Pace:</source>
+        <translation>Lépés:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Sebesség: </translation>
+        <source>Speed:</source>
+        <translation>Sebesség:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Pulzus: </translation>
+        <source>Heartrate:</source>
+        <translation>Pulzus:</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-laufhelden-nl.ts
+++ b/translations/harbour-laufhelden-nl.ts
@@ -251,27 +251,27 @@
         <translation>Snelheid</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Tijd: </translation>
+        <source>Time:</source>
+        <translation>Tijd:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Duur: </translation>
+        <source>Duration:</source>
+        <translation>Duur:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Hoogte: </translation>
+        <source>Elevation:</source>
+        <translation>Hoogte:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Tempo: </translation>
+        <source>Pace:</source>
+        <translation>Tempo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Snelheid: </translation>
+        <source>Speed:</source>
+        <translation>Snelheid:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation>Hartslag</translation>
     </message>
     <message>
@@ -513,27 +513,27 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
-        <translation>Tijd: </translation>
+        <source>Time:</source>
+        <translation>Tijd:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Duur: </translation>
+        <source>Duration:</source>
+        <translation>Duur:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation>Hoogte</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Tempo: </translation>
+        <source>Pace:</source>
+        <translation>Tempo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Snelheid: </translation>
+        <source>Speed:</source>
+        <translation>Snelheid:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation>Hartslag; </translation>
     </message>
     <message>

--- a/translations/harbour-laufhelden-nl_BE.ts
+++ b/translations/harbour-laufhelden-nl_BE.ts
@@ -251,27 +251,27 @@
         <translation type="unfinished">Snelheid</translation>
     </message>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -513,27 +513,27 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/harbour-laufhelden-pl.ts
+++ b/translations/harbour-laufhelden-pl.ts
@@ -251,28 +251,28 @@
         <translation>Prędkość</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Czas: </translation>
+        <source>Time:</source>
+        <translation>Czas:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Czas trwania: </translation>
+        <source>Duration:</source>
+        <translation>Czas trwania:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Wzniesienie: </translation>
+        <source>Elevation:</source>
+        <translation>Wzniesienie:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Tempo: </translation>
+        <source>Pace:</source>
+        <translation>Tempo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Prędkość: </translation>
+        <source>Speed:</source>
+        <translation>Prędkość:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Tętno: </translation>
+        <source>Heartrate:</source>
+        <translation>Tętno:</translation>
     </message>
     <message>
         <source>km</source>
@@ -513,28 +513,28 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
-        <translation>Czas: </translation>
+        <source>Time:</source>
+        <translation>Czas:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Czss trwania: </translation>
+        <source>Duration:</source>
+        <translation>Czss trwania:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Wzniesienie: </translation>
+        <source>Elevation:</source>
+        <translation>Wzniesienie:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Tempo: </translation>
+        <source>Pace:</source>
+        <translation>Tempo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Prędkość: </translation>
+        <source>Speed:</source>
+        <translation>Prędkość:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Tętno: </translation>
+        <source>Heartrate:</source>
+        <translation>Tętno:</translation>
     </message>
     <message>
         <source>km</source>

--- a/translations/harbour-laufhelden-ru.ts
+++ b/translations/harbour-laufhelden-ru.ts
@@ -256,28 +256,28 @@
         <translation>Шаг</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Время: </translation>
+        <source>Time:</source>
+        <translation>Время:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Длительность: </translation>
+        <source>Duration:</source>
+        <translation>Длительность:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Подъём: </translation>
+        <source>Elevation:</source>
+        <translation>Подъём:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Шаг: </translation>
+        <source>Pace:</source>
+        <translation>Шаг:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Скорость: </translation>
+        <source>Speed:</source>
+        <translation>Скорость:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Пульс: </translation>
+        <source>Heartrate:</source>
+        <translation>Пульс:</translation>
     </message>
     <message>
         <source>km</source>
@@ -518,28 +518,28 @@
         <translation>Карта</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Время: </translation>
+        <source>Time:</source>
+        <translation>Время:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Длительность: </translation>
+        <source>Duration:</source>
+        <translation>Длительность:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Подъём: </translation>
+        <source>Elevation:</source>
+        <translation>Подъём:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Шаг: </translation>
+        <source>Pace:</source>
+        <translation>Шаг:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Скорость: </translation>
+        <source>Speed:</source>
+        <translation>Скорость:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Пульс: </translation>
+        <source>Heartrate:</source>
+        <translation>Пульс:</translation>
     </message>
     <message>
         <source>km</source>

--- a/translations/harbour-laufhelden-sv.ts
+++ b/translations/harbour-laufhelden-sv.ts
@@ -251,28 +251,28 @@
         <translation>Hastighet</translation>
     </message>
     <message>
-        <source>Time: </source>
-        <translation>Tid: </translation>
+        <source>Time:</source>
+        <translation>Tid:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Varaktighet: </translation>
+        <source>Duration:</source>
+        <translation>Varaktighet:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Stigning: </translation>
+        <source>Elevation:</source>
+        <translation>Stigning:</translation>
     </message>
     <message>
-        <source>Pace: </source>
-        <translation>Tempo: </translation>
+        <source>Pace:</source>
+        <translation>Tempo:</translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Hastighet: </translation>
+        <source>Speed:</source>
+        <translation>Hastighet:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Hjärtfrekvens: </translation>
+        <source>Heartrate:</source>
+        <translation>Hjärtfrekvens:</translation>
     </message>
     <message>
         <source>km</source>
@@ -513,28 +513,28 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
-        <translation>Tid: </translation>
+        <source>Time:</source>
+        <translation>Tid:</translation>
     </message>
     <message>
-        <source>Duration: </source>
-        <translation>Varaktighet: </translation>
+        <source>Duration:</source>
+        <translation>Varaktighet:</translation>
     </message>
     <message>
-        <source>Elevation: </source>
-        <translation>Stigning: </translation>
+        <source>Elevation:</source>
+        <translation>Stigning:</translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation>Tempo; </translation>
     </message>
     <message>
-        <source>Speed: </source>
-        <translation>Hastighet: </translation>
+        <source>Speed:</source>
+        <translation>Hastighet:</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
-        <translation>Hjärtfrekvens: </translation>
+        <source>Heartrate:</source>
+        <translation>Hjärtfrekvens:</translation>
     </message>
     <message>
         <source>km</source>

--- a/translations/harbour-laufhelden-zh_CN.ts
+++ b/translations/harbour-laufhelden-zh_CN.ts
@@ -255,27 +255,27 @@
         <translation>步数</translation>
     </message>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation>时间：</translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation>持续时间：</translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation>海拔；</translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation>步数：</translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation>速度；</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation>心率：</translation>
     </message>
     <message>
@@ -517,27 +517,27 @@
         <translation>地图</translation>
     </message>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation>时间：</translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation>持续时间：</translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation>海拔：</translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation>步数;</translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation>速率：</translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation>心率</translation>
     </message>
     <message>

--- a/translations/harbour-laufhelden.ts
+++ b/translations/harbour-laufhelden.ts
@@ -251,27 +251,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -513,27 +513,27 @@
 <context>
     <name>MapViewPage</name>
     <message>
-        <source>Time: </source>
+        <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Duration: </source>
+        <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Elevation: </source>
+        <source>Elevation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pace: </source>
+        <source>Pace:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Speed: </source>
+        <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Heartrate: </source>
+        <source>Heartrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
I have uniformized the InfoLabels: no space is necessary to add to the label.
(Removed the spaces from all translations with this script: https://gist.github.com/martonmiklos/21764ffd726721abd6ace295bd816f1f)

- Adjusted some paddings in the about dialog: the authors are now padded a bit.
- The Detailed view items are padded a bit from left
- The map and diagrams page left column InfoLabels are padded a bit