### PR TITLE
Make the GraphDatas last value display optional. 

### DIFF
--- a/qml/graph/GraphData.qml
+++ b/qml/graph/GraphData.qml
@@ -33,7 +33,8 @@ Item {
     }
 
     property var valueConverter
-    property bool valueTotal: false
+
+    property bool displayLastValue: false
 
     property int graphHeight: 250
     property int graphWidth: canvas.width / canvas.stepX
@@ -118,7 +119,7 @@ Item {
                 color: Theme.highlightColor
                 font.pixelSize: Theme.fontSizeSmall
                 wrapMode: Text.Wrap
-                visible: !noData
+                visible: !noData && displayLastValue
             }
         }
 
@@ -236,6 +237,8 @@ Item {
                 }
 
                 onPaint: {
+                    if (!visible)
+                        return;
                     var ctx = canvas.getContext("2d");
                     ctx.globalCompositeOperation = "source-over";
                     ctx.clearRect(0,0,width,height);
@@ -273,13 +276,12 @@ Item {
                     ctx.stroke();
                     ctx.restore();
 
-                    if (end > 0) {
-                        var lastValue = valueSum;
-                        if (!root.valueTotal) {
-                            lastValue = points[end-1].y;
-                        }
-                        if (lastValue) {
-                            labelLastValue.text = root.createYLabel(lastValue)+root.axisY.units;
+                    if (displayLastValue) {
+                        if (end > 0) {
+                            var lastValue = points[end-1].y;
+                            if (lastValue)
+                                labelLastValue.text = root.createYLabel(lastValue)+root.axisY.units;
+                            console.log(root.createYLabel(lastValue)+root.axisY.units);
                         }
                     }
                 }

--- a/qml/pages/DiagramViewPage.qml
+++ b/qml/pages/DiagramViewPage.qml
@@ -209,6 +209,7 @@ Page
         {
             anchors.verticalCenter: parent.verticalCenter
             id: graphElevation
+            displayLastValue: true
             graphTitle: qsTr("Elevation")
             graphHeight: parent.height / 4.4
 


### PR DESCRIPTION
Displaying the last value in the top right corner of the graphs does not makes a lot of sense in graphs other than elevation. (For e.g. usually in the case of speed it will display some close to zero speed what I run when I hit the stop button.)

I also added an optimalization: the paint callback is skipped for hidden graphs.

By thinking it further it would be useful to move the current values of the graphs there to spare some screen esate at the bottom. 